### PR TITLE
Fix Reporting of Benchmark Performance

### DIFF
--- a/Python/LuxonisOak/main.py
+++ b/Python/LuxonisOak/main.py
@@ -44,7 +44,7 @@ if __name__ == '__main__':
 
         # timing: for benchmarking purposes
         t = time.time()-t0
-        print("INFERENCE TIME IN MS ", 1/t)
+        print("FPS ", 1/t)
         print("PREDICTIONS ", [p.json() for p in predictions])
 
         # Uncomment the follow two lines to enable


### PR DESCRIPTION
# Description

There is a print statement that is wrong for benchmarking Oak device performance. This change fixes it.

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Not tested. Just a change to a print statement string. 

